### PR TITLE
Add SCP project

### DIFF
--- a/.github/workflows/generate-scp-entry.yml
+++ b/.github/workflows/generate-scp-entry.yml
@@ -1,0 +1,50 @@
+name: Generate SCP Entry
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Run daily at midnight UTC
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  generate-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run SCP generator
+        run: python scp-runner.py
+        env:
+          DOTTXT_API_KEY: ${{ secrets.DOTTXT_API_KEY }}
+          DOTTXT_HOST: ${{ secrets.DOTTXT_HOST }}
+
+      - name: Configure Git
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+
+      - name: Create and switch to gh-pages branch
+        run: |
+          git checkout -b gh-pages
+          git pull origin gh-pages || true
+
+      - name: Copy generated files
+        run: |
+          mkdir -p scp/entries
+          cp -R entries/* scp/entries/
+
+      - name: Commit and push changes
+        run: |
+          git add scp/entries
+          git commit -m "Add new SCP entry" || echo "No changes to commit"
+          git push origin gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*/__pycache__/
+scp/entries
+*.env

--- a/scp/README.md
+++ b/scp/README.md
@@ -6,6 +6,7 @@ This Python script generates SCP (Secure, Contain, Protect) entries and saves th
 Special thanks to [all the contributors](https://scp-wiki.wikidot.com/authors-pages) of the SCP wiki over the years! This would never be possible without the creativity, passion, and dedication of the SCP community.
 
 ## Features
+
 - Supports various SCP object classes: Safe, Euclid, Keter, Thaumiel, and more can be added as needed.
 - Generates SCP entries with the following sections:
   - Item Number
@@ -57,11 +58,14 @@ print(f"Entry saved to {entry.filepath()}")
 This will generate a new SCP entry, save it to the `entries` directory, and print the file path.
 
 ## Customization
-You can customize the script by:
 
+You can customize the SCP generator by editing the `classes.py` file.
+
+- `scp_prompt()` can be modified to change the prompt for the SCP generator.
 - Adding new `ObjectClass` values as needed.
 - Modifying the `ContainmentProcedures`, `Description`, `Addendum`, and `Note` models to fit your desired SCP entry structure.
 - Adjusting the text generation and formatting in the `save()` method of the `SCP` model.
 
 ## Contributing
+
 If you find any issues or have suggestions for improvements, feel free to open an issue or submit a pull request.

--- a/scp/api.py
+++ b/scp/api.py
@@ -1,0 +1,155 @@
+"""
+ _______________________________
+/ Don't want to self-host?       \
+\\ Try .json at http://dottxt.co /
+ -------------------------------
+       \\   ^__^
+        \\  (oo)\\_______
+            (__)\\       )\\/\
+                ||----w |
+                ||     ||
+
+This code generate one SCP entry a day using the .txt API, .json.
+
+The code is runnable without an API key, but may be useful when
+the .json service is more widely available.
+
+To run this code locally, please run `scp.py` instead.
+"""
+
+import hashlib
+import json
+import os
+import time
+import requests
+from dotenv import load_dotenv
+from typing import Optional
+from requests.exceptions import HTTPError
+
+load_dotenv(override=True)
+
+# Create schema-to-js_id mapping
+API_HOST = os.environ.get("DOTTXT_API_HOST", None)
+API_KEY = os.environ.get("DOTTXT_API_KEY", None)
+
+def check_api_key() -> None:
+    if not API_KEY:
+        raise ValueError("DOTTXT_API_KEY environment variable is not set")
+
+def get_headers(api_key: Optional[str] = None) -> dict:
+    if api_key is None:
+        check_api_key()
+        api_key = API_KEY
+    return {"Authorization": f"Bearer {api_key}"}
+
+SCHEMA_HASH_TO_COMPLETION_URL = {}
+
+def to_hash(pydantic_class):
+    schema = pydantic_class.model_json_schema()
+    schema_string = json.dumps(schema)
+    return hashlib.sha256(schema_string.encode()).hexdigest()
+
+def poll_status(url: str, api_key: Optional[str] = None) -> dict:
+    headers = get_headers(api_key)
+    while True:
+        status_res = requests.get(url, headers=headers)
+        status_json = status_res.json()
+        if status_res.status_code != 200 or status_json["status"] != "in_progress":
+            break
+        time.sleep(1)
+    return status_json
+
+def get_schema_by_name(name: str, api_key: Optional[str] = None) -> Optional[dict]:
+    headers = get_headers(api_key)
+    try:
+        response = requests.get(f"https://{API_HOST}/v1/json-schemas", headers=headers)
+        response.raise_for_status()
+        schemas = response.json()['items']
+
+        for schema in schemas:
+            if schema['name'] == name:
+                return schema
+        return None
+    except HTTPError as e:
+        if e.response.status_code == 403:
+            raise ValueError("Authentication failed. Please check your API key.") from e
+        else:
+            raise
+    except Exception as e:
+        raise
+
+
+def create_schema(schema: str, name: str, api_key: Optional[str] = None) -> dict:
+    data = {"name": name, "json_schema": schema}
+    headers = get_headers(api_key)
+    try:
+        response = requests.post(
+            f"https://{API_HOST}/v1/json-schemas",
+            headers=headers,
+            json=data
+        )
+        response.raise_for_status()
+        return response.json()
+    except HTTPError as e:
+        if e.response.status_code == 403:
+            raise ValueError("Authentication failed. Please check your API key.") from e
+        else:
+            raise
+    except Exception as e:
+        raise
+
+
+def get_completion_endpoint(model_class, api_key: Optional[str] = None):
+    schema_hash = to_hash(model_class)
+
+    if schema_hash in SCHEMA_HASH_TO_COMPLETION_URL:
+        completion_url = SCHEMA_HASH_TO_COMPLETION_URL[schema_hash]
+        return completion_url
+
+    # Check next to see if the schema_has is already stored by checking
+    # GET https://api.dottxt.co/v1/json-schemas
+    schema_response = get_schema_by_name(schema_hash, api_key)
+
+    # If the schema exists poll the status and return the completion URL
+    if schema_response:
+        status_url = schema_response["status_url"]
+        final_status = poll_status(status_url, api_key)
+        completion_url = final_status["completion_url"]
+        if completion_url:
+            SCHEMA_HASH_TO_COMPLETION_URL[schema_hash] = completion_url
+            return completion_url
+
+    # Okay, we don't have a completion URL for this schema. Let's create it.
+    schema_string = json.dumps(model_class.model_json_schema())
+    schema_response = create_schema(schema_string, schema_hash, api_key)
+
+    # If we get here, we need to wait for the schema to be created
+    status_url = schema_response["status_url"]
+    final_status = poll_status(status_url, api_key)
+
+    completion_url = final_status["completion_url"]
+    if not completion_url:
+        raise ValueError(f"No completion URL available for schema: {schema_hash}")
+
+    SCHEMA_HASH_TO_COMPLETION_URL[schema_hash] = completion_url
+    return completion_url
+
+def create_completion(
+    model_class,
+    prompt: str,
+    max_tokens: int = 31999,
+    api_key: Optional[str] = None
+):
+    completion_url = get_completion_endpoint(model_class, api_key)
+    data = {"prompt": prompt, "max_tokens": max_tokens}
+    headers = get_headers(api_key)
+    completion_response = requests.post(completion_url, headers=headers, json=data)
+    completion_response.raise_for_status()
+
+    # get json
+    completion_response_json = completion_response.json()
+
+    # convert to pydantic model
+    model = model_class.model_validate_json(completion_response_json['data'])
+
+    return model

--- a/scp/classes.py
+++ b/scp/classes.py
@@ -227,8 +227,6 @@ class SCP(BaseModel):
         with open(file_path, "w") as file:
             file.write(str(self))
 
-        print(f"SCP entry saved to {file_path}")
-
 
 def scp_system_prompt(json_schema: str) -> str:
     return f"""
@@ -436,3 +434,4 @@ def redo_prompt(result: SCP, feedback: Reviewer) -> str:
     <|im_end|>
     <|im_start|>assistant
     """
+

--- a/scp/classes.py
+++ b/scp/classes.py
@@ -1,0 +1,156 @@
+"""
+If you want to make this code less hideous, please do!
+
+part of the curse is the ugly code
+
+- cameron
+"""
+
+import os
+
+from pydantic import BaseModel, Field
+from typing import List, Optional
+from enum import Enum
+
+class ObjectClass(str, Enum):
+    SAFE = "Safe"
+    EUCLID = "Euclid"
+    KETER = "Keter"
+    THAUMIEL = "Thaumiel"
+    # Add other classes as needed
+
+class ContainmentProcedures(BaseModel):
+    physical_requirements: str = Field(..., description="Physical requirements for containing the SCP")
+    security_measures: str = Field(..., description="Security measures required for the SCP")
+    handling_instructions: str = Field(..., description="Instructions for handling the SCP")
+    other_precautions: Optional[str] = Field(None, description="Additional precautions if necessary")
+
+class Description(BaseModel):
+    physical_appearance: Optional[str] = Field(None, description="Physical description of the SCP")
+    anomalous_properties: str = Field(..., description="Anomalous properties of the SCP")
+    origin: Optional[str] = Field(None, description="Origin of the SCP, if known")
+    relevant_history: Optional[str] = Field(None, description="Relevant historical information about the SCP")
+
+class Addendum(BaseModel):
+    title: str = Field(..., description="Title of the addendum")
+    content: str = Field(..., description="Content of the addendum")
+
+class Note(BaseModel):
+    content: str = Field(..., description="Content of the note")
+
+class SCP(BaseModel):
+    item_number: str = Field(..., pattern=r"^SCP-\d+$", description="Unique identifier for the SCP")
+    object_class: ObjectClass = Field(..., description="Classification of the SCP's containment difficulty")
+    containment_procedures: ContainmentProcedures = Field(..., description="Procedures for containing the SCP")
+    description: Description = Field(..., description="Detailed description of the SCP")
+    addenda: List[Addendum] = Field(default_factory=list, description="Additional information about the SCP")
+    notes: List[Note] = Field(default_factory=list, description="Miscellaneous notes about the SCP")
+
+    def filepath(self, scp_dir):
+        return os.path.join(scp_dir, f"{self.item_number}.txt")
+
+    def save(self, scp_dir):
+        # Generate the file path
+        file_path = self.filepath(scp_dir)
+
+        # Check for existing files with the same SCP number
+        if os.path.exists(file_path):
+            existing_files = [f for f in os.listdir(scp_dir) if f.startswith("SCP-")]
+            existing_numbers = [int(f.split("-")[1].split(".")[0]) for f in existing_files]
+            new_number = max(existing_numbers) + 1
+            old_number = self.item_number
+            self.item_number = f"SCP-{new_number:03d}"
+            file_path = os.path.join(scp_dir, f"{self.item_number}.txt")
+
+            # Update all fields containing the old SCP number
+            for field in self.model_fields.values():
+                if isinstance(getattr(self, field.name), str):
+                    setattr(self, field.name, getattr(self, field.name).replace(old_number, self.item_number))
+                elif isinstance(getattr(self, field.name), list):
+                    for i, item in enumerate(getattr(self, field.name)):
+                        if isinstance(item, BaseModel):
+                            for sub_field in item.model_fields.values():
+                                if isinstance(getattr(item, sub_field.name), str):
+                                    setattr(item, sub_field.name, getattr(item, sub_field.name).replace(old_number, self.item_number))
+                        elif isinstance(item, str):
+                            getattr(self, field.name)[i] = item.replace(old_number, self.item_number)
+
+        # Create the SCP entry text
+        scp_text = f"# {self.item_number}\n\n"
+        scp_text += f"## Item #: {self.item_number}\n\n"
+        scp_text += f"## Object Class: [{self.object_class}]\n\n"
+
+        # Add the containment procedures
+        scp_text += "## Special Containment Procedures\n\n"
+
+        scp_text += f"{self.containment_procedures.physical_requirements}\n\n"
+        scp_text += f"{self.containment_procedures.security_measures}\n\n"
+        scp_text += f"{self.containment_procedures.handling_instructions}\n\n"
+
+        if self.containment_procedures.other_precautions:
+            scp_text += f"{self.containment_procedures.other_precautions}\n\n"
+        scp_text += "## Description:\n\n"
+        if self.description.physical_appearance:
+            scp_text += f"{self.description.physical_appearance}\n\n"
+        scp_text += f"{self.description.anomalous_properties}\n\n"
+        if self.description.origin:
+            scp_text += f"{self.description.origin}\n\n"
+        if self.description.relevant_history:
+            scp_text += f"{self.description.relevant_history}\n\n"
+        if self.addenda:
+            scp_text += "## Addendum:\n\n"
+            for index, addendum in enumerate(self.addenda, start=1):
+                scp_text += f"### Addendum {self.item_number}.{index}: {addendum.title}\n\n"
+                scp_text += f"{addendum.content}\n\n"
+        if self.notes:
+            scp_text += "## Notes:\n\n"
+            for note in self.notes:
+                scp_text += f"{note.content}\n\n"
+
+        # Write the SCP entry to the file
+        with open(file_path, "w") as file:
+            file.write(scp_text)
+
+        print(f"SCP entry saved to {file_path}")
+
+def scp_prompt() -> str:
+    # Make the JSON schema
+    json_schema = SCP.model_json_schema()
+
+    return f"""
+    <|im_start|>system
+    Your role is to create SCP entries. An SCP entry is a document that
+    describes an anomalous object, phenomenon, or entity, and the procedures
+    and precautions that must be taken to contain it.
+
+    You must provide
+
+    - An SCP number in the format SCP-[number]
+    - The object class of the SCP, which is one of the following: Safe, Euclid, Keter, or Thaumiel
+    - The special containment procedures for the SCP. Be detailed and specific. A reader of this
+      SCP entry should be able to contain the SCP without any ambiguity. SCP entities may be dangerous
+      or require special handling, and so the containment procedures are of the utmost importance.
+    - The description of the SCP, including its physical appearance, anomalous properties,
+      origin, and relevant history.
+    - Any addenda to the SCP, which are additional documents that provide more information about the SCP.
+      Addenda are optional, but can help provide more context about the SCP and its anomalies. Addenda
+      typically come in the form of documents, logs, or other records that provide more information about
+      the history of the SCP's acquisition, experimentation, and any other important information.
+    - Any notes that are relevant to the SCP. Notes are optional, and can provide additional information
+      about the SCP that is not covered elsewhere. Notes can be used to provide speculation, theorizing,
+      or other information that is relevant to the SCP.
+
+    You must provide all the above fields in valid JSON. Your schema is:
+
+    ```json
+    {json_schema}
+    ```
+
+    <|im_end|>
+    <|im_start|>user
+
+    Please produce an SCP entry.
+
+    <|im_end|>
+    <|im_start|>assistant
+    """

--- a/scp/scp-runner.py
+++ b/scp/scp-runner.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 
 from api import create_completion
-from classes import SCP, Reviewer, reviewer_prompt, scp_prompt
+from classes import SCP, Reviewer, apply_scp_theme, reviewer_prompt, scp_prompt
 
 # Where the entries are stored
 scp_dir = "entries"
@@ -28,6 +28,13 @@ entry = create_completion(SCP, scp_prompt())
 entry.save(scp_dir)
 print(f"Entry saved to {entry.filepath(scp_dir)}")
 
+# Save the entry to HTML
+html_content = entry.to_html()
+html_path = entry.html_filepath(scp_dir)
+with open(html_path, "w") as f:
+    f.write(html_content)
+print(f"HTML saved to {html_path}")
+
 # Review it
 review = create_completion(Reviewer, reviewer_prompt(entry))
 
@@ -38,8 +45,8 @@ print(f"Review saved to {review_path}")
 
 # Generate an index.html file
 index_file = os.path.join(scp_dir, "index.html")
-entries = [f for f in os.listdir(scp_dir) if f.endswith(".txt")]
-entry_names = [f.replace(".txt", "") for f in entries]
+entries = [f for f in os.listdir(scp_dir) if f.endswith(".html") and f != "index.html"]
+entry_names = [f.replace(".html", "") for f in entries]
 
 html_content = f"""
 <!DOCTYPE html>
@@ -47,22 +54,63 @@ html_content = f"""
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>SCP Entries Index</title>
+    <title>SCP Foundation - Secure, Contain, Protect</title>
     <style>
-        body {{ font-family: Arial, sans-serif; line-height: 1.6; padding: 20px; }}
-        h1 {{ color: #333; }}
-        ul {{ list-style-type: none; padding: 0; }}
-        li {{ margin-bottom: 10px; }}
-        a {{ color: #0066cc; text-decoration: none; }}
-        a:hover {{ text-decoration: underline; }}
+        body {{
+            font-family: 'Courier New', monospace;
+            line-height: 1.6;
+            padding: 20px;
+            background-color: #f0f0f0;
+            color: #333;
+        }}
+        .container {{
+            max-width: 800px;
+            margin: 0 auto;
+            background-color: #fff;
+            padding: 20px;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+        }}
+        h1 {{
+            color: #990000;
+            text-align: center;
+            border-bottom: 2px solid #990000;
+            padding-bottom: 10px;
+        }}
+        ul {{
+            list-style-type: none;
+            padding: 0;
+        }}
+        li {{
+            margin-bottom: 10px;
+            padding: 10px;
+            background-color: #f9f9f9;
+            border-left: 3px solid #990000;
+        }}
+        a {{
+            color: #990000;
+            text-decoration: none;
+            font-weight: bold;
+        }}
+        a:hover {{
+            text-decoration: underline;
+        }}
+        .update-info {{
+            text-align: right;
+            font-style: italic;
+            margin-top: 20px;
+            color: #666;
+        }}
     </style>
 </head>
 <body>
-    <h1>SCP Entries Index</h1>
-    <p>Last updated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}</p>
-    <ul>
-        {"".join(f'<li><a href="{entry}">{entry_name}</a></li>' for entry_name, entry in sorted(zip(entry_names, entries), key=lambda x: x[0]))}
-    </ul>
+    <div class="container">
+        <h1>SCP Foundation Archives</h1>
+        <ul>
+            {"".join(f'<li><a href="{entry}">{entry_name}</a></li>' for entry_name, entry in sorted(zip(entry_names, entries), key=lambda x: x[0]))}
+        </ul>
+        <p class="update-info">Last updated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}</p>
+    </div>
 </body>
 </html>
 """

--- a/scp/scp-runner.py
+++ b/scp/scp-runner.py
@@ -7,6 +7,7 @@ from enum import Enum
 import json
 import os
 
+from api import create_completion
 from classes import SCP, scp_prompt
 
 # Where the entries are stored
@@ -17,17 +18,9 @@ if not os.path.exists(scp_dir):
     # Make it
     os.makedirs(scp_dir)
 
+# Call the api
+entry = create_completion(SCP, scp_prompt())
 
-# Using outlines locally
-model = outlines.models.transformers(
-    "microsoft/Phi-3-mini-128k-instruct",
-    device="cpu"
-)
-
-# Make the generator
-scp_generator = outlines.generate.json(model, SCP)
-
-# Make a new one
-entry = scp_generator(scp_prompt())
+# Save it to disk
 entry.save(scp_dir)
 print(f"Entry saved to {entry.filepath(scp_dir)}")

--- a/scp/scp-runner.py
+++ b/scp/scp-runner.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 
 from api import create_completion
-from classes import SCP, Reviewer, reviewer_prompt, scp_prompt
+from classes import SCP, Reviewer, redo_prompt, reviewer_prompt, scp_prompt
 
 # Where the entries are stored
 scp_dir = "entries"
@@ -30,7 +30,7 @@ entry.save(scp_dir)
 print(f"Entry saved to {entry.filepath(scp_dir)}")
 
 # Review it
-review = create_completion(Reviewer, reviewer_prompt())
+review = create_completion(Reviewer, reviewer_prompt(entry))
 
 # Save it to disk
 review_path = os.path.join(review_dir, f"{entry.item_number}.txt")
@@ -40,6 +40,7 @@ print(f"Review saved to {review_path}")
 # Generate an index.html file
 index_file = os.path.join(scp_dir, "index.html")
 entries = [f for f in os.listdir(scp_dir) if f.endswith(".txt")]
+entry_names = [f.replace(".txt", "") for f in entries]
 
 html_content = f"""
 <!DOCTYPE html>
@@ -61,7 +62,7 @@ html_content = f"""
     <h1>SCP Entries Index</h1>
     <p>Last updated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}</p>
     <ul>
-        {"".join(f'<li><a href="{entry}">{entry[:-5]}</a></li>' for entry in sorted(entries))}
+        {"".join(f'<li><a href="{entry}">{entry_name}</a></li>' for entry_name, entry in sorted(zip(entry_names, entries), key=lambda x: x[0]))}
     </ul>
 </body>
 </html>

--- a/scp/scp-runner.py
+++ b/scp/scp-runner.py
@@ -7,20 +7,19 @@ import os
 from datetime import datetime
 
 from api import create_completion
-from classes import SCP, Reviewer, redo_prompt, reviewer_prompt, scp_prompt
+from classes import SCP, Reviewer, reviewer_prompt, scp_prompt
 
 # Where the entries are stored
 scp_dir = "entries"
 review_dir = "entries/reviews"
 
 # Check if entries and reviews folders exist
-if not os.path.exists(scp_dir):
-    # Make it
-    os.makedirs(scp_dir)
+dirs = [scp_dir, review_dir]
+for dir in dirs:
+    if not os.path.exists(dir):
+        # Make it
+        os.makedirs(dir)
 
-if not os.path.exists(review_dir):
-    # Make it
-    os.makedirs(review_dir)
 
 # Call the api
 entry = create_completion(SCP, scp_prompt())

--- a/scp/scp-runner.py
+++ b/scp/scp-runner.py
@@ -4,17 +4,23 @@ from typing import List, Optional
 from enum import Enum
 import json
 import os
+from datetime import datetime
 
 from api import create_completion
-from classes import SCP, scp_prompt
+from classes import SCP, Reviewer, reviewer_prompt, scp_prompt
 
 # Where the entries are stored
 scp_dir = "entries"
+review_dir = "entries/reviews"
 
-# Check if folder exists
+# Check if entries and reviews folders exist
 if not os.path.exists(scp_dir):
     # Make it
     os.makedirs(scp_dir)
+
+if not os.path.exists(review_dir):
+    # Make it
+    os.makedirs(review_dir)
 
 # Call the api
 entry = create_completion(SCP, scp_prompt())
@@ -23,10 +29,45 @@ entry = create_completion(SCP, scp_prompt())
 entry.save(scp_dir)
 print(f"Entry saved to {entry.filepath(scp_dir)}")
 
-# Generate an index file
-index_file = os.path.join(scp_dir, "index.json")
-entries = [f for f in os.listdir(scp_dir) if f.endswith(".json") and f != "index.json"]
+# Review it
+review = create_completion(Reviewer, reviewer_prompt())
+
+# Save it to disk
+review_path = os.path.join(review_dir, f"{entry.item_number}.txt")
+review.save(review_path)
+print(f"Review saved to {review_path}")
+
+# Generate an index.html file
+index_file = os.path.join(scp_dir, "index.html")
+entries = [f for f in os.listdir(scp_dir) if f.endswith(".txt")]
+
+html_content = f"""
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SCP Entries Index</title>
+    <style>
+        body {{ font-family: Arial, sans-serif; line-height: 1.6; padding: 20px; }}
+        h1 {{ color: #333; }}
+        ul {{ list-style-type: none; padding: 0; }}
+        li {{ margin-bottom: 10px; }}
+        a {{ color: #0066cc; text-decoration: none; }}
+        a:hover {{ text-decoration: underline; }}
+    </style>
+</head>
+<body>
+    <h1>SCP Entries Index</h1>
+    <p>Last updated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}</p>
+    <ul>
+        {"".join(f'<li><a href="{entry}">{entry[:-5]}</a></li>' for entry in sorted(entries))}
+    </ul>
+</body>
+</html>
+"""
+
 with open(index_file, "w") as f:
-    json.dump(entries, f)
+    f.write(html_content)
 
 print(f"Index file updated: {index_file}")

--- a/scp/scp-runner.py
+++ b/scp/scp-runner.py
@@ -1,9 +1,7 @@
-import outlines # the best package on earth
-
+import outlines
 from pydantic import BaseModel, Field
 from typing import List, Optional
 from enum import Enum
-
 import json
 import os
 
@@ -24,3 +22,11 @@ entry = create_completion(SCP, scp_prompt())
 # Save it to disk
 entry.save(scp_dir)
 print(f"Entry saved to {entry.filepath(scp_dir)}")
+
+# Generate an index file
+index_file = os.path.join(scp_dir, "index.json")
+entries = [f for f in os.listdir(scp_dir) if f.endswith(".json") and f != "index.json"]
+with open(index_file, "w") as f:
+    json.dump(entries, f)
+
+print(f"Index file updated: {index_file}")


### PR DESCRIPTION
Implements an SCP generating script that uses .json to push a new entry each day. 

- Separated out common prompts + classes so the local + remote scripts will be in sync.
- Add HTML theming to SCP entries
- Added `Reviewer` agent to review SCP entries. These are stored in `scp/entries/reviews`. Currently they're not used due to context window restrictions.
- Added workflow to call the script and push the entries to `gh-pages`